### PR TITLE
Finally bug fixed with inputs

### DIFF
--- a/src/components/hotspotIcon/index.jsx
+++ b/src/components/hotspotIcon/index.jsx
@@ -17,12 +17,17 @@ export default class HotspotIcon extends Component {
     }
 
     showInput(event) {
-        event.target.offsetParent.querySelector("input").style.display = "block"
+        console.log(event.target)
+        event.target.nextElementSibling.style.display = "block"
         event.target.style.display = "none"
+    }
+
+
+    componentDidMount() {
+
     }
     
     updateBody(event) {
-        console.log(event)
         store.dispatch(spotUpdater(parseInt(event.target.dataset.id) - 1, "body", event.target.value))
         window.localStorage.setItem("Hotspots", JSON.stringify(store.getState().hotspotCreator.hotspots));
         event.target.offsetParent.querySelector("p").innerText = event.target.value
@@ -30,22 +35,18 @@ export default class HotspotIcon extends Component {
         event.target.style.display = "none"
     }
     updateTitle(event) {
-        console.log("title")
         store.dispatch(spotUpdater(parseInt(event.target.dataset.id) - 1, "title", event.target.value))
         window.localStorage.setItem("Hotspots", JSON.stringify(store.getState().hotspotCreator.hotspots));
         event.target.offsetParent.querySelector("h4").innerText = event.target.value
         event.target.offsetParent.querySelector("h4").style.display = "block"
         event.target.style.display = "none"
-    }
-
-    
- 
+    } 
 
     render() {
         return (
             <React.Fragment>
                 {
-                    store.getState().hotspotCreator.hotspots.map(spot => {
+                    store.getState().hotspotCreator.hotspots.map((spot, index) => {
                         return (
                             <div className="hotspot" key={`a${this.keyGentr()}`} style={{left: spot.x, top: spot.y}}>
                                 <div className="red-out" key={`b${this.keyGentr()}`}>
@@ -55,11 +56,11 @@ export default class HotspotIcon extends Component {
                                 <div className="hotspot-info no-spot pointer" key={`e${this.keyGentr()}`} >
                                     <div onDoubleClick={this.spotEditor} className="hotspot-info-title no-spot" key={`f${this.keyGentr()}`} >
                                         <h4 className="no-spot" onDoubleClick={this.showInput} key={`g${this.keyGentr()}`}>{spot.title}</h4>
-                                        <input type="text" onBlur={this.updateTitle} data-id={store.getState().hotspotCreator.hotspots.indexOf(spot) + 1} defaultValue={"Click twice to edit"} className="title-input editable-input no-spot" key={`h${this.keyGentr()}`}/>
+                                        <input type="text" onBlur={this.updateTitle} data-id={index + 1} defaultValue={"Click out the input to save"} className="title-input editable-input no-spot" key={`h${this.keyGentr()}`}/>
                                     </div>      
                                     <div onDoubleClick={this.spotEditor} className="hotspot-info-body no-spot primary-text-color" key={`i${this.keyGentr()}`}>
                                         <p className="no-spot" onDoubleClick={this.showInput} key={`j${this.keyGentr()}`}>{spot.body}</p> 
-                                        <input type="text" onBlur={this.updateBody} data-id={store.getState().hotspotCreator.hotspots.indexOf(spot) + 1} defaultValue={"Click twice to edit"} className="body-input editable-input no-spot" key={`k${this.keyGentr()}`}/>
+                                        <input type="text" onBlur={this.updateBody} data-id={index + 1} defaultValue={"Click out the input to save"} className="body-input editable-input no-spot" key={`k${this.keyGentr()}`}/>
                                     </div>
                                 </div>
                             </div>

--- a/src/components/hotspotIcon/style.css
+++ b/src/components/hotspotIcon/style.css
@@ -1,9 +1,6 @@
 .hotspot {
     position: absolute;
-    left: 50%;
-    top: 50%;
     z-index: 2;
-    /* pointer-events: none; */
     transform: translate(-4%, -79%);
 }
 
@@ -57,18 +54,22 @@
 .hotspot-info.pointer::after {
     content: "";
     position: absolute;
-    width: 20px;
-    height: 20px;
-    background-color: #fff;
-    top: -9px;
+    width: 0;
+    height: 0;
+    border-top: 0;
+    border-right: 15px solid transparent;
+    border-left: 15px solid transparent;
+    border-bottom: 17px solid #fff;
+    filter: drop-shadow(0px -3px 2px rgba(0, 0, 0, .1));
+    top: -15px;
     left: 50%;
-    z-index: 999;
-    transform: rotate(46deg);
+    z-index: -1;
+    transform: translateX(-50%);
 }
 
-.hotspot-info-title {
+.hotspot-info-title h4 {
     font-size: 130%;
-    margin-bottom: 20px;
+    margin: 10px 0 20px 0;
     color: #444;
 }
 

--- a/src/redux/reducers/redSpotCreator.js
+++ b/src/redux/reducers/redSpotCreator.js
@@ -11,9 +11,9 @@ const ReducerSpotCreator = (state = INITIAL_STATE, action) => {
             const newState = [...state.hotspots.slice(0, id), ...state.hotspots.slice(id + 1)]
             return { hotspots: [...newState] };
         case "UPDATING_SPOT":
-            const stateUpdated = state.hotspots[action.id][action.field] = action.value;
-            console.log(stateUpdated)
-            return state
+            const stateUpdated = state.hotspots
+            stateUpdated[action.id][action.field] = action.value;
+            return { hotspots: [...stateUpdated] }
         default:
             return state
     }


### PR DESCRIPTION
When the user had to input a data in the new hotspot created, for some
reason, only the first input was displayed, and when the user left,
naturally only the title got updated.

The problem was that the function written to show the inputs, was
getting and showing exclusively the first input.